### PR TITLE
add cronjobs file and basic function that replicated button push

### DIFF
--- a/api/src/utils/cronjobs.ts
+++ b/api/src/utils/cronjobs.ts
@@ -1,0 +1,49 @@
+#! /app/.heroku/node/bin/node
+import { logError, logInfo, logWarning, logSuccess} from "./logger"
+import {
+    getRandomRaEventArtists, 
+    getRandomSoundcloudTrack,
+    generateSoundcloudEmbed
+} from "./raScraper"
+import { format } from 'date-fns'
+
+import { Crawler } from "../utils/Crawler";
+
+const getCurrentDate = () => format(new Date(), 'yyyy-MM-dd')
+
+const pushButton = async ()=>{
+    // This function simulates a single button push from the front end
+    const date = getCurrentDate()
+    const location = 'berlin'
+    const autoPlay = true
+
+    const crawler = new Crawler();
+    await crawler.init();
+    const page =  await crawler.getPage();
+
+    const randomRaEventDetails = await getRandomRaEventArtists(
+        location as string,
+        date as string,
+        page
+      );
+
+    const randomSoundcloudTrack = await getRandomSoundcloudTrack(
+        randomRaEventDetails.randomEventScLink
+      );
+      logSuccess(`SOUNDCLOUD TRACK: ${randomSoundcloudTrack}`);
+
+    const soundcloudOembed = await generateSoundcloudEmbed(
+        randomSoundcloudTrack,
+        // Should extendx Red.query type definitions
+        (autoPlay as unknown) as boolean
+    );
+}
+
+const runJobs = async()=>{
+    await pushButton()
+    process.exit()
+
+}
+
+runJobs()
+


### PR DESCRIPTION
added a basic script to put daily caching jobs into

tbd exactly how this will work with heroku - apparently needs to be in the "bin" directory

https://stackoverflow.com/questions/13345664/using-heroku-scheduler-with-node-js

file works with command: ts-node api/src/utils/cronjobs.ts

