### PR TITLE
add google analytics ID via env variable

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -4,8 +4,8 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './app/App';
 import ReactGA from 'react-ga';
 
-const TRACKING_ID = "UA-213321254-1"; 
-ReactGA.initialize(TRACKING_ID);
+const ANALYTICS_ID = process.env.REACT_APP_ANALYTICS_ID||"";
+ReactGA.initialize(ANALYTICS_ID);
 ReactGA.pageview(window.location.pathname);
 
 


### PR DESCRIPTION
analytics ID set as environment variables

defaults to empty string if no variable is set